### PR TITLE
Use sysdig role from osism.services collection

### DIFF
--- a/playbooks/generic-sysdig.yml
+++ b/playbooks/generic-sysdig.yml
@@ -3,5 +3,8 @@
   hosts: all
   serial: "{{ osism_serial['sysdig']|default('0') }}"
 
+  collections:
+    - osism.services
+
   roles:
-  - role: osism.sysdig
+    - role: sysdig


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>