### PR TITLE
Use rsyslog role from osism.services collection (#29)

### DIFF
--- a/playbooks/generic-rsyslog.yml
+++ b/playbooks/generic-rsyslog.yml
@@ -2,7 +2,9 @@
 - name: Apply role rsyslog
   hosts: all
   serial: "{{ osism_serial['rsyslog']|default(osism_serial_default)|default(0) }}"
-  become: true
+
+  collections:
+    - osism.services
 
   roles:
-  - role: osism.rsyslog
+    - role: rsyslog


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>