### PR TITLE
Use internal_address as default fluentd host

### DIFF
--- a/group_vars/all/defaults.yml
+++ b/group_vars/all/defaults.yml
@@ -54,3 +54,8 @@ network_restart_method: nothing
 
 osism_serial: []
 osism_serial_default: 30%
+
+##########################
+# osism.services.rsyslog
+
+fluentd_host: "{{ internal_address }}"


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>